### PR TITLE
Support pricing for second location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GN Additional Stock Location
 
-This WordPress plugin adds a second stock location field to WooCommerce products. When an order is processed the stock is reduced from both locations accordingly.
+This WordPress plugin adds a second stock location field to WooCommerce products. It also lets you set a different price for items coming from that location. When an order is processed the stock is reduced from both locations accordingly and the price from the active location is used.
 
 ## Installation
 
@@ -8,7 +8,8 @@ This WordPress plugin adds a second stock location field to WooCommerce products
 2. Activate the plugin from the **Plugins** page in the WordPress admin.
 
 After activation, a **2nd Stock Location** field will appear in the product inventory tab.
-For variable products, each variation has its own **2nd Stock Location** field inside the variation inventory section.
+A **2nd Location Price** field is also added in the pricing section. For variable products each variation gets its own pair of fields for stock and price.
+When the primary location runs out of stock the plugin automatically uses the price from the 2nd location.
 
 ## Updates
 


### PR DESCRIPTION
## Summary
- add a 2nd Location Price field for products and variations
- use price from location 2 when the primary stock is empty
- document new pricing behaviour

## Testing
- `php -l gn-additional-stock-location.php`
- `find . -name '*.php' | xargs -I{} php -l {}`


------
https://chatgpt.com/codex/tasks/task_e_68862402723c832789946d6a15e2a7fb