### PR TITLE
Add sale price support for second location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ GN Additional Stock Location extends WooCommerce with a second inventory locatio
 
 - Second **Stock Location** field on the inventory tab for simple and variable products.
 - **2nd Location Price** field that is used when the primary location runs out of stock.
+- **2nd Location Sale Price** to offer discounts when location two is active.
 - Stock status and available quantity are based on the sum of both locations.
 - Automatic price switching once the primary location is empty.
 - Order processing reduces stock from both locations and logs changes on the order.
@@ -16,6 +17,10 @@ GN Additional Stock Location extends WooCommerce with a second inventory locatio
 1. Copy the `gn-additional-stock-location` directory to your site's `wp-content/plugins` folder.
 2. Activate the plugin from the **Plugins** page in the WordPress admin.
 3. Edit a product and enter values for the second location stock and price. Variations have the same fields.
+
+## Sale Price for Location Two
+
+Set **2nd Location Sale Price** to offer a discounted amount when stock from the second location is being sold. The sale price only applies once the primary stock level reaches zero. Regular WooCommerce sale functionality for the main price is unaffected.
 
 ## Updates
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,11 +12,15 @@ Adds a second stock location field to WooCommerce products and manages pricing a
 == Description ==
 This plugin lets you track inventory in a secondary location for every WooCommerce product. Each item also gets an optional price that is used once the primary location runs out of stock. Stock quantities and status are calculated based on the combined total and orders automatically reduce quantities in both locations. The plugin also ships with an update checker that can pull new versions from GitHub.
 
+When the primary location is empty you can also specify a **2nd Location Sale Price** to offer a discount on items stored in the secondary location.
+
 == Installation ==
 1. Upload the `gn-additional-stock-location` folder to your `/wp-content/plugins/` directory.
 2. Activate the plugin from **Plugins** in the WordPress admin.
 3. Edit a product to enter values for **2nd Stock Location** and **2nd Location Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.3.0 =
+* Added sale price support for the second location.
 = 1.2.0 =
 * Initial release


### PR DESCRIPTION
## Summary
- support a sale price for the secondary stock location
- save new fields for products and variations
- handle discount logic in pricing filters
- document new functionality

## Testing
- `php -l gn-additional-stock-location.php`

------
https://chatgpt.com/codex/tasks/task_e_68862c4d8af08327aa7d9bbdef36e25d