### PR TITLE
Add dropdown for location name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ GN Additional Stock Location extends WooCommerce with a second inventory locatio
 - **Golden Sneakers Sale Price** to offer discounts when location two is active.
 - Stock status and available quantity are based on the sum of both locations.
 - Automatic price switching once the primary location is empty.
+- Dropdown **Location Name** field lets you switch between Sneakfreaks and Golden Sneakers.
 - Order processing reduces stock from both locations and logs changes on the order.
 - Built in update checker pulls new releases from GitHub.
 
@@ -24,7 +25,7 @@ Set **Golden Sneakers Sale Price** to offer a discounted amount when stock from 
 
 ## Location Name Meta
 
-Each product stores the name of the secondary location in a read-only meta field. This field also appears on the product page so customers can see which location is active.
+Each product stores the active location name in a dropdown field so you can choose between your predefined locations. The selected name also appears on the product page so customers can see which location is active.
 
 ## Updates
 

--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.4.0
+ * Version: 1.5.0
  * Author: Your Name
  */
 
@@ -256,12 +256,15 @@ function gn_asl_save_additional_sale_price_variation( $variation_id, $i ) {
 function gn_asl_location_name_field() {
    global $product_object;
    echo '<div class="show_if_simple show_if_variable">';
-   woocommerce_wp_text_input(
+   woocommerce_wp_select(
       array(
-         'id'                => '_location2_name',
-         'value'             => get_post_meta( $product_object->get_id(), '_location2_name', true ) ?: GN_ASL_PRIMARY_LOCATION_NAME,
-         'label'             => 'Location Name',
-         'custom_attributes' => array( 'readonly' => 'readonly' ),
+         'id'          => '_location2_name',
+         'value'       => get_post_meta( $product_object->get_id(), '_location2_name', true ) ?: GN_ASL_PRIMARY_LOCATION_NAME,
+         'label'       => 'Location Name',
+         'options'     => array(
+            GN_ASL_PRIMARY_LOCATION_NAME   => GN_ASL_PRIMARY_LOCATION_NAME,
+            GN_ASL_SECONDARY_LOCATION_NAME => GN_ASL_SECONDARY_LOCATION_NAME,
+         ),
       )
    );
    echo '</div>';
@@ -275,14 +278,17 @@ function gn_asl_location_name_field() {
  * @param WP_Post $variation Variation post object.
  */
 function gn_asl_location_name_field_variation( $loop, $data, $variation ) {
-   woocommerce_wp_text_input(
+   woocommerce_wp_select(
       array(
-         'id'                => "variable_location2_name{$loop}",
-         'name'              => "variable_location2_name[{$loop}]",
-         'value'             => get_post_meta( $variation->ID, '_location2_name', true ) ?: GN_ASL_PRIMARY_LOCATION_NAME,
-         'label'             => 'Location Name',
-         'custom_attributes' => array( 'readonly' => 'readonly' ),
-         'wrapper_class'     => 'form-row form-row-full',
+         'id'            => "variable_location2_name{$loop}",
+         'name'          => "variable_location2_name[{$loop}]",
+         'value'         => get_post_meta( $variation->ID, '_location2_name', true ) ?: GN_ASL_PRIMARY_LOCATION_NAME,
+         'label'         => 'Location Name',
+         'options'       => array(
+            GN_ASL_PRIMARY_LOCATION_NAME   => GN_ASL_PRIMARY_LOCATION_NAME,
+            GN_ASL_SECONDARY_LOCATION_NAME => GN_ASL_SECONDARY_LOCATION_NAME,
+         ),
+         'wrapper_class' => 'form-row form-row-full',
       )
    );
 }
@@ -294,12 +300,8 @@ function gn_asl_save_location_name( $product_id ) {
     global $typenow;
     if ( 'product' === $typenow ) {
         if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
-        $stock2 = get_post_meta( $product_id, '_stock2', true );
-        $price2 = get_post_meta( $product_id, '_price2', true );
-        if ( (float) $stock2 > 0 && '' !== $price2 ) {
-            update_post_meta( $product_id, '_location2_name', GN_ASL_SECONDARY_LOCATION_NAME );
-        } else {
-            update_post_meta( $product_id, '_location2_name', GN_ASL_PRIMARY_LOCATION_NAME );
+        if ( isset( $_POST['_location2_name'] ) ) {
+            update_post_meta( $product_id, '_location2_name', sanitize_text_field( wp_unslash( $_POST['_location2_name'] ) ) );
         }
     }
 }
@@ -309,12 +311,8 @@ function gn_asl_save_location_name( $product_id ) {
  */
 function gn_asl_save_location_name_variation( $variation_id, $i ) {
    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
-   $stock2 = get_post_meta( $variation_id, '_stock2', true );
-   $price2 = get_post_meta( $variation_id, '_price2', true );
-   if ( (float) $stock2 > 0 && '' !== $price2 ) {
-      update_post_meta( $variation_id, '_location2_name', GN_ASL_SECONDARY_LOCATION_NAME );
-   } else {
-      update_post_meta( $variation_id, '_location2_name', GN_ASL_PRIMARY_LOCATION_NAME );
+   if ( isset( $_POST['variable_location2_name'][ $i ] ) ) {
+      update_post_meta( $variation_id, '_location2_name', sanitize_text_field( wp_unslash( $_POST['variable_location2_name'][ $i ] ) ) );
    }
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,12 +3,12 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.4.0
+Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Adds a second stock location called **Golden Sneakers** to WooCommerce products and manages pricing and stock levels automatically. The default WooCommerce location is referred to as **Sneakfreaks**.
-Each product stores the name of the active location in a read-only meta field displayed on the edit screen and the product page.
+Each product stores the active location name in a dropdown field displayed on the edit screen and the product page so you can select between your predefined locations.
 
 == Description ==
 This plugin lets you track inventory in a secondary location for every WooCommerce product. Each item also gets an optional price that is used once the primary location runs out of stock. Stock quantities and status are calculated based on the combined total and orders automatically reduce quantities in both locations. The plugin also ships with an update checker that can pull new versions from GitHub.
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.5.0 =
+* Location Name field is now a dropdown that lets you choose between Sneakfreaks and Golden Sneakers.
 = 1.4.0 =
 * Location name now defaults to Sneak Freaks and switches to Golden Sneakers only when the second stock and price are set.
 = 1.3.0 =


### PR DESCRIPTION
## Summary
- make location name selectable via dropdown for both products and variations
- update plugin version to 1.5.0
- document new behavior in README and plugin readme

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l plugin-update-checker/load-v5p6.php`
- `php -l plugin-update-checker/plugin-update-checker.php`


------
https://chatgpt.com/codex/tasks/task_e_6886381ad0e88327a1d9968fdbc9c106