### PR TITLE
Fix price field layout and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.5.1
+ * Version: 1.6.0
  * Author: George Nicolaou
  */
 
@@ -95,6 +95,7 @@ function gn_asl_additional_price_location() {
          'value' => get_post_meta( $product_object->get_id(), '_price2', true ),
          'label' => GN_ASL_SECONDARY_LOCATION_NAME . ' Price',
          'data_type' => 'price',
+         'wrapper_class' => 'form-row form-row-first',
       )
    );
    echo '</div>';
@@ -117,6 +118,7 @@ function gn_asl_additional_sale_price_location() {
          'value' => get_post_meta( $product_object->get_id(), '_sale_price2', true ),
          'label' => GN_ASL_SECONDARY_LOCATION_NAME . ' Sale Price',
          'data_type' => 'price',
+         'wrapper_class' => 'form-row form-row-last',
       )
    );
    echo '</div>';
@@ -138,7 +140,7 @@ function gn_asl_additional_price_location_variation( $loop, $variation_data, $va
          'value'         => get_post_meta( $variation->ID, '_price2', true ),
          'label'         => GN_ASL_SECONDARY_LOCATION_NAME . ' Price',
          'data_type'     => 'price',
-         'wrapper_class' => 'form-row form-row-full',
+         'wrapper_class' => 'form-row form-row-first',
       )
    );
 }
@@ -159,7 +161,7 @@ function gn_asl_additional_sale_price_location_variation( $loop, $variation_data
          'value'         => get_post_meta( $variation->ID, '_sale_price2', true ),
          'label'         => GN_ASL_SECONDARY_LOCATION_NAME . ' Sale Price',
          'data_type'     => 'price',
-         'wrapper_class' => 'form-row form-row-full',
+         'wrapper_class' => 'form-row form-row-last',
       )
    );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.5.0
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.6.0 =
+* Golden Sneakers price fields display side by side.
 = 1.5.1 =
 * Updater fix.
 = 1.5.0 =


### PR DESCRIPTION
## Summary
- style Golden Sneakers price fields to sit side by side
- bump plugin version to 1.6.0 and update changelog

## Testing
- `php -l gn-additional-stock-location.php`

------
https://chatgpt.com/codex/tasks/task_e_688644728ed8832794fb8878a29d6b8c