### PR TITLE
Fix layout for stock fields and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: George Nicolaou
  */
 
@@ -48,10 +48,11 @@ function gn_asl_additional_stock_location() {
    echo '<div class="show_if_simple show_if_variable">';
    woocommerce_wp_text_input(
       array(
-         'id' => '_stock2',
-         'value' => get_post_meta( $product_object->get_id(), '_stock2', true ),
-         'label' => GN_ASL_SECONDARY_LOCATION_NAME . ' Stock',
-         'data_type' => 'stock',
+         'id'           => '_stock2',
+         'value'        => get_post_meta( $product_object->get_id(), '_stock2', true ),
+         'label'        => GN_ASL_SECONDARY_LOCATION_NAME . ' Stock',
+         'data_type'    => 'stock',
+         'wrapper_class'=> 'form-row form-row-first',
       )
    );
    echo '</div>';
@@ -73,7 +74,7 @@ function gn_asl_additional_stock_location_variation( $loop, $variation_data, $va
          'value'         => get_post_meta( $variation->ID, '_stock2', true ),
          'label'         => GN_ASL_SECONDARY_LOCATION_NAME . ' Stock',
          'data_type'     => 'stock',
-         'wrapper_class' => 'form-row form-row-full',
+         'wrapper_class' => 'form-row form-row-first',
       )
    );
 }
@@ -273,13 +274,14 @@ function gn_asl_location_name_field() {
    echo '<div class="show_if_simple show_if_variable">';
    woocommerce_wp_select(
       array(
-         'id'          => '_location2_name',
-         'value'       => get_post_meta( $product_object->get_id(), '_location2_name', true ) ?: GN_ASL_PRIMARY_LOCATION_NAME,
-         'label'       => 'Location Name',
-         'options'     => array(
+         'id'           => '_location2_name',
+         'value'        => get_post_meta( $product_object->get_id(), '_location2_name', true ) ?: GN_ASL_PRIMARY_LOCATION_NAME,
+         'label'        => 'Location Name',
+         'options'      => array(
             GN_ASL_PRIMARY_LOCATION_NAME   => GN_ASL_PRIMARY_LOCATION_NAME,
             GN_ASL_SECONDARY_LOCATION_NAME => GN_ASL_SECONDARY_LOCATION_NAME,
          ),
+         'wrapper_class'=> 'form-row form-row-last',
       )
    );
    echo '</div>';
@@ -303,7 +305,7 @@ function gn_asl_location_name_field_variation( $loop, $data, $variation ) {
             GN_ASL_PRIMARY_LOCATION_NAME   => GN_ASL_PRIMARY_LOCATION_NAME,
             GN_ASL_SECONDARY_LOCATION_NAME => GN_ASL_SECONDARY_LOCATION_NAME,
          ),
-         'wrapper_class' => 'form-row form-row-full',
+         'wrapper_class' => 'form-row form-row-last',
       )
    );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.6.0
+Stable tag: 1.7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.7.0 =
+* Golden Sneakers Stock and Location Name fields display side by side.
 = 1.6.0 =
 * Golden Sneakers price fields display side by side.
 = 1.5.1 =


### PR DESCRIPTION
## Summary
- show Golden Sneakers stock and location fields in one row
- bump plugin version to 1.7.0

## Testing
- `php -l gn-additional-stock-location.php`

------
https://chatgpt.com/codex/tasks/task_e_688648cad5688327b37b93ff4b421d5a