### PR TITLE
Make location names filterable and fix stock status

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.7.0
+Stable tag: 1.8.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,10 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.8.0 =
+* Location names are now filterable via `gn_asl_primary_location_name` and `gn_asl_secondary_location_name`.
+* Fixed double-counting of secondary stock in stock status filter.
+* Centralized total stock calculation.
 = 1.7.0 =
 * Golden Sneakers Stock and Location Name fields display side by side.
 = 1.6.0 =


### PR DESCRIPTION
## Summary
- Allow themes or plugins to filter primary and secondary location names
- Avoid double-counting secondary stock by centralizing total stock logic and using it for stock status
- Bump plugin version to 1.8.0 and update changelog

## Testing
- `php -l gn-additional-stock-location.php`


------
https://chatgpt.com/codex/tasks/task_e_6898a2ff45bc83278a7c3e29a65b56b3