### PR TITLE
Fix logger inclusion and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: George Nicolaou
  */
 
@@ -499,12 +499,14 @@ function gn_asl_maybe_reduce_second_stock( $reduce, $order_id ) {
    }
    $order->get_data_store()->set_stock_reduced( $order_id, true );
    return false;
-
-   // Load the WP All Import sync + logger module (only if Woo + WPAI present).
-if ( ! defined('ABSPATH') ) exit;
-$__gn_asl_module = __DIR__ . '/includes/class-gn-asl-import-sync.php';
-if ( file_exists($__gn_asl_module) ) {
-    require_once $__gn_asl_module;
 }
 
+/**
+ * Load the WP All Import sync + logger module (only if WooCommerce is active).
+ */
+if ( class_exists( 'WooCommerce' ) ) {
+   $module_file = __DIR__ . '/includes/class-gn-asl-import-sync.php';
+   if ( file_exists( $module_file ) ) {
+      require_once $module_file;
+   }
 }

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -249,10 +249,4 @@ final class Module {
 
 // Boot when plugins loaded
 add_action('plugins_loaded', [\GN_ASL\ImportSync\Module::class, 'boot'], 20);
-// Load the WP All Import sync + logger module if WooCommerce is active.
-if ( class_exists( 'WooCommerce' ) ) {
-    $sync_file = __DIR__ . '/includes/class-gn-asl-import-sync.php';
-    if ( file_exists( $sync_file ) ) {
-        require_once $sync_file;
-    }
-}
+

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.8.1 =
+* Fixed WP All Import logger not loading and ensured module inclusion.
+
 = 1.8.0 =
 * Location names are now filterable via `gn_asl_primary_location_name` and `gn_asl_secondary_location_name`.
 * Fixed double-counting of secondary stock in stock status filter.


### PR DESCRIPTION
## Summary
- ensure WP All Import sync + logger module loads when WooCommerce is active
- remove redundant self-inclusion from import sync module
- bump plugin version to 1.8.1 and document changelog

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a21590bb48327b88e1b71984b0ae3