### PR TITLE
Move import log to top-level menu and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.8.1
+ * Version: 1.9.0
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -191,15 +191,16 @@ final class Module {
         ]);
     }
 
-    /** Admin submenu under WooCommerce. */
+    /** Admin top-level menu for the import log. */
     public static function admin_menu() : void {
-        add_submenu_page(
-            'woocommerce',
+        add_menu_page(
             'ASL Import Log',
             'ASL Import Log',
             'manage_woocommerce',
             'gn-asl-import-log',
-            [__CLASS__, 'render_log_page']
+            [__CLASS__, 'render_log_page'],
+            'dashicons-media-text',
+            56
         );
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.8.1
+Stable tag: 1.9.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.0 =
+* Moved import log to its own top-level menu.
+
 = 1.8.1 =
 * Fixed WP All Import logger not loading and ensured module inclusion.
 


### PR DESCRIPTION
## Summary
- Expose import log under its own top-level menu for easier access
- Bump plugin version to 1.9.0 and update readme

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a23675d808327976952147b2d9948