### PR TITLE
Fix import log access for administrators

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.0
+ * Version: 1.9.1
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -193,10 +193,11 @@ final class Module {
 
     /** Admin top-level menu for the import log. */
     public static function admin_menu() : void {
+        $capability = current_user_can('manage_woocommerce') ? 'manage_woocommerce' : 'manage_options';
         add_menu_page(
             'ASL Import Log',
             'ASL Import Log',
-            'manage_woocommerce',
+            $capability,
             'gn-asl-import-log',
             [__CLASS__, 'render_log_page'],
             'dashicons-media-text',

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.0
+Stable tag: 1.9.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.1 =
+* Allow administrators without WooCommerce management capability to access the Import Log page.
+
 = 1.9.0 =
 * Moved import log to its own top-level menu.
 


### PR DESCRIPTION
## Summary
- allow admins without WooCommerce capabilities to view ASL Import Log
- bump plugin version to 1.9.1 and update changelog

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a299ca5648327934589426cb1c977