### PR TITLE
Boot Import Log module and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.1
+ * Version: 1.9.2
  * Author: George Nicolaou
  */
 
@@ -508,5 +508,12 @@ if ( class_exists( 'WooCommerce' ) ) {
    $module_file = __DIR__ . '/includes/class-gn-asl-import-sync.php';
    if ( file_exists( $module_file ) ) {
       require_once $module_file;
+
+      // Boot the module so it registers hooks & the admin page.
+      add_action( 'plugins_loaded', function () {
+         if ( class_exists( '\GN_ASL\ImportSync\Module' ) ) {
+            \GN_ASL\ImportSync\Module::boot();
+         }
+      }, 20 );
    }
 }

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -249,6 +249,3 @@ final class Module {
     }
 }
 
-// Boot when plugins loaded
-add_action('plugins_loaded', [\GN_ASL\ImportSync\Module::class, 'boot'], 20);
-

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.1
+Stable tag: 1.9.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.2 =
+* Boot Import Log module so the admin page is registered.
+
 = 1.9.1 =
 * Allow administrators without WooCommerce management capability to access the Import Log page.
 


### PR DESCRIPTION
## Summary
- ensure Import Log module is booted via `plugins_loaded`
- bump plugin version to 1.9.2 and update changelog

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a2c0f30d48327b733fa758893763b