### PR TITLE
Add dedicated menu for import log and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.2
+ * Version: 1.9.3
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -191,18 +191,36 @@ final class Module {
         ]);
     }
 
-    /** Admin top-level menu for the import log. */
+    /** Admin top-level menu for the plugin with Import Log submenu. */
     public static function admin_menu() : void {
-        $capability = current_user_can('manage_woocommerce') ? 'manage_woocommerce' : 'manage_options';
+        $capability  = current_user_can('manage_woocommerce') ? 'manage_woocommerce' : 'manage_options';
+        $parent_slug = 'gn-asl';
+
         add_menu_page(
-            'ASL Import Log',
-            'ASL Import Log',
+            'GN ASL',
+            'GN ASL',
             $capability,
-            'gn-asl-import-log',
-            [__CLASS__, 'render_log_page'],
+            $parent_slug,
+            [__CLASS__, 'render_main_page'],
             'dashicons-media-text',
             56
         );
+
+        add_submenu_page(
+            $parent_slug,
+            'Import Log',
+            'Import Log',
+            $capability,
+            'gn-asl-import-log',
+            [__CLASS__, 'render_log_page']
+        );
+
+        remove_submenu_page($parent_slug, $parent_slug);
+    }
+
+    /** Render main plugin page. */
+    public static function render_main_page() : void {
+        echo '<div class="wrap"><h1>GN Additional Stock Location</h1></div>';
     }
 
     /** Render log page with clear + tail. */

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.2
+Stable tag: 1.9.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.3 =
+* Move Import Log under its own top-level GN ASL menu.
 = 1.9.2 =
 * Boot Import Log module so the admin page is registered.
 


### PR DESCRIPTION
## Summary
- Give the Import Log its own parent menu outside WooCommerce
- Provide placeholder main page for new menu and organize Import Log as a submenu
- Bump plugin version to 1.9.3 and update readme

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a2e6d4d9483279c7c1134ce1fc7ad