### PR TITLE
Fix GN ASL module load order and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.3
+ * Version: 1.9.4
  * Author: George Nicolaou
  */
 
@@ -502,18 +502,16 @@ function gn_asl_maybe_reduce_second_stock( $reduce, $order_id ) {
 }
 
 /**
- * Load the WP All Import sync + logger module (only if WooCommerce is active).
+ * Load the WP All Import sync + logger module.
  */
-if ( class_exists( 'WooCommerce' ) ) {
-   $module_file = __DIR__ . '/includes/class-gn-asl-import-sync.php';
-   if ( file_exists( $module_file ) ) {
-      require_once $module_file;
+$module_file = __DIR__ . '/includes/class-gn-asl-import-sync.php';
+if ( file_exists( $module_file ) ) {
+   require_once $module_file;
 
-      // Boot the module so it registers hooks & the admin page.
-      add_action( 'plugins_loaded', function () {
-         if ( class_exists( '\GN_ASL\ImportSync\Module' ) ) {
-            \GN_ASL\ImportSync\Module::boot();
-         }
-      }, 20 );
-   }
+   // Boot the module so it registers hooks & the admin page.
+   add_action( 'plugins_loaded', function () {
+      if ( class_exists( 'WooCommerce' ) && class_exists( '\GN_ASL\ImportSync\Module' ) ) {
+         \GN_ASL\ImportSync\Module::boot();
+      }
+   }, 20 );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.3
+Stable tag: 1.9.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.4 =
+* Ensure GN ASL module loads after WooCommerce so the Import Log menu is always available.
 = 1.9.3 =
 * Move Import Log under its own top-level GN ASL menu.
 = 1.9.2 =


### PR DESCRIPTION
## Summary
- ensure import sync module boots after WooCommerce so GN ASL menu appears
- bump plugin version to 1.9.4 and document change

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a32c404dc83279c722d64be7c8509