### PR TITLE
Handle missing import ID in pmxi_saved_post

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.4
+ * Version: 1.9.5
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -54,8 +54,14 @@ final class Module {
         @file_put_contents(self::log_path(), $line, FILE_APPEND);
     }
 
-    /** pmxi_saved_post — after WPAI creates/updates a record. */
-    public static function on_saved_post($post_id, $xml, $is_update, $import_id) : void {
+    /**
+     * pmxi_saved_post — after WPAI creates/updates a record.
+     *
+     * WP All Import 4.8+ passes only three arguments to this action. The fourth
+     * parameter $import_id is therefore optional for backwards compatibility
+     * with older versions that still provided it.
+     */
+    public static function on_saved_post($post_id, $xml, $is_update, $import_id = 0) : void {
         $sku = get_post_meta($post_id, '_sku', true);
         if (empty($sku)) {
             self::log('Saved post has no SKU; skipping.', compact('post_id','import_id','is_update'));

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.4
+Stable tag: 1.9.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.5 =
+* Restore compatibility with WP All Import by making the `pmxi_saved_post` hook's import ID parameter optional.
 = 1.9.4 =
 * Ensure GN ASL module loads after WooCommerce so the Import Log menu is always available.
 = 1.9.3 =


### PR DESCRIPTION
## Summary
- Avoid fatal errors when WP All Import's `pmxi_saved_post` hook omits the import ID by making the parameter optional
- Bump plugin version to 1.9.5 and update readme

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689a35789ea8832793b8f9c611227af4