### PR TITLE
Add descriptive SKU match logging with product titles

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.6
+ * Version: 1.9.7
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.6
+Stable tag: 1.9.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,8 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.7 =
+* Log SKU matches with detailed product and variation titles.
 = 1.9.6 =
 * Log whether a matched SKU belongs to a parent product or variation.
 = 1.9.5 =


### PR DESCRIPTION
## Summary
- Log duplicate SKU matches with detailed product and variation titles
- Log forced-update SKU matches with product titles
- Bump plugin version to 1.9.7

## Testing
- `php -l includes/class-gn-asl-import-sync.php`
- `php -l gn-additional-stock-location.php`


------
https://chatgpt.com/codex/tasks/task_e_689a448b94bc83279e9486432e3c07b1