### PR TITLE
chore: bump plugin version to 1.9.9

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.8
+ * Version: 1.9.9
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.8
+Stable tag: 1.9.9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.9 =
+* Bump version to 1.9.9.
+
 = 1.9.8 =
 * Improve import logs to show received values and whether meta fields were updated.
 = 1.9.7 =


### PR DESCRIPTION
## Summary
- bump plugin version to 1.9.9 and document release in changelog

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689b014e70048327860632cab1c578d3