### PR TITLE
Fix WP All Import timing, prevent empty meta writes

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.9
+ * Version: 1.9.10
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.9
+Stable tag: 1.9.10
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.10 =
+* Read stock and price data via WooCommerce after WP All Import saves it and avoid overwriting existing values with empty meta.
+
 = 1.9.9 =
 * Bump version to 1.9.9.
 


### PR DESCRIPTION
## Summary
- Run post-import handler at later priority and add optional after-import hook
- Fetch stock and price data through WooCommerce getters and log accurate snapshots
- Avoid overwriting existing meta with empty values when merging duplicates
- Bump plugin version to 1.9.10

## Testing
- `php -l includes/class-gn-asl-import-sync.php`
- `php -l gn-additional-stock-location.php`


------
https://chatgpt.com/codex/tasks/task_e_689b0a5225fc83278c27a1e7f8ba81d3