### PR TITLE
Verify import data and bump to 1.9.11

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.10
+ * Version: 1.9.11
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.10
+Stable tag: 1.9.11
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.11 =
+* Log mismatches between feed data and saved meta values to verify imports.
+
 = 1.9.10 =
 * Read stock and price data via WooCommerce after WP All Import saves it and avoid overwriting existing values with empty meta.
 


### PR DESCRIPTION
## Summary
- Log and compare feed values against saved meta to detect mismatches
- Bump plugin version to 1.9.11 with updated changelog

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_689b6c7062b88327834ee7913651aa70