### PR TITLE
Sanitize secondary stock save

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.11
+ * Version: 1.9.12
  * Author: George Nicolaou
  */
 
@@ -187,7 +187,11 @@ function gn_asl_save_additional_stock( $product_id ) {
     if ( 'product' === $typenow ) {
       if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
       if ( isset( $_POST['_stock2'] ) ) {
-         update_post_meta( $product_id, '_stock2', $_POST['_stock2'] );
+         if ( ! function_exists( 'wc_stock_amount' ) ) {
+            return;
+         }
+         $qty = wc_stock_amount( wp_unslash( $_POST['_stock2'] ) );
+         update_post_meta( $product_id, '_stock2', $qty );
       }
    }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.11
+Stable tag: 1.9.12
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.12 =
+* Sanitize saved secondary stock with `wc_stock_amount`.
+
 = 1.9.11 =
 * Log mismatches between feed data and saved meta values to verify imports.
 


### PR DESCRIPTION
## Summary
- sanitize saved secondary stock using `wc_stock_amount`
- bump plugin version to 1.9.12 and document change

## Testing
- `php -l gn-additional-stock-location.php`

------
https://chatgpt.com/codex/tasks/task_e_68b5ebb52e588327a54a9f0abb6e5752