### PR TITLE
Improve WP All Import logging and restrict to import ID 3

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.12
+ * Version: 1.9.13
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.12
+Stable tag: 1.9.13
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.13 =
+* Restrict sync to WP All Import ID 3 and format log entries into readable blocks.
+
 = 1.9.12 =
 * Sanitize saved secondary stock with `wc_stock_amount`.
 


### PR DESCRIPTION
## Summary
- handle only WP All Import import ID 3
- format logger output into readable blocks per product
- bump plugin version to 1.9.13

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5f99103a88327b59a6171ca623589