### PR TITLE
Fix import log path and bump version to 1.9.14

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.13
+ * Version: 1.9.14
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -51,7 +51,9 @@ final class Module {
 
     /** Get absolute path to log (uploads dir). */
     private static function log_path() : string {
-        $uploads = wp_get_upload_dir();
+        // wp_get_upload_dir() doesn't create the directory. wp_upload_dir()
+        // ensures the uploads path exists so our log file can be written.
+        $uploads = wp_upload_dir();
         return trailingslashit($uploads['basedir']) . self::LOG_FILE;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.13
+Stable tag: 1.9.14
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.14 =
+* Ensure import log file is created even if the uploads directory is missing.
+
 = 1.9.13 =
 * Restrict sync to WP All Import ID 3 and format log entries into readable blocks.
 


### PR DESCRIPTION
## Summary
- Ensure uploads directory exists before writing the import log by switching to `wp_upload_dir`
- Bump plugin version to 1.9.14 and document the change

## Testing
- `php -l includes/class-gn-asl-import-sync.php`
- `php -l gn-additional-stock-location.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5fc1d657c8327ba01cb9941ac8aee