### PR TITLE
Add import log diagnostics and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.15
+ * Version: 1.9.16
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -410,6 +410,38 @@ final class Module {
         }
 
         echo '<div class="wrap"><h1>ASL Import Log</h1>';
+
+        $issues   = [];
+        $uploads  = wp_upload_dir();
+        $log_file = self::log_path();
+
+        if ( ! defined('WP_DEBUG') || ! WP_DEBUG ) {
+            $issues[] = 'WP_DEBUG is disabled. gn_asl_debug_log() will not output messages.';
+        }
+
+        if ( ! is_dir( $uploads['basedir'] ) ) {
+            $issues[] = 'Uploads directory missing: ' . $uploads['basedir'];
+        } elseif ( ! is_writable( $uploads['basedir'] ) ) {
+            $issues[] = 'Uploads directory is not writable: ' . $uploads['basedir'];
+        } elseif ( file_exists( $log_file ) && ! is_writable( $log_file ) ) {
+            $issues[] = 'Log file is not writable: ' . $log_file;
+        }
+
+        if ( did_action( 'pmxi_saved_post' ) === 0 ) {
+            $issues[] = 'WP All Import hooks have not fired. Ensure an import runs with ID ' . self::IMPORT_ID . '.';
+        }
+
+        if ( empty( $issues ) ) {
+            echo '<div class="notice notice-success"><p>No issues detected.</p></div>';
+            gn_asl_debug_log( 'test message' );
+        } else {
+            echo '<div class="notice notice-warning"><p>The following checks may help diagnose missing log entries:</p><ul>';
+            foreach ( $issues as $issue ) {
+                echo '<li>' . esc_html( $issue ) . '</li>';
+            }
+            echo '</ul></div>';
+        }
+
         echo '<form method="post" style="margin-bottom:12px;">';
         wp_nonce_field('gnasl_clear_log');
         submit_button('Clear Log', 'delete', 'gnasl_clear_log', false);

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.15
+Stable tag: 1.9.16
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.16 =
+* Add diagnostics on Import Log page to help troubleshoot missing log entries.
+
 = 1.9.15 =
 * Add debug logging to track execution of key functions.
 


### PR DESCRIPTION
## Summary
- Add diagnostics to Import Log admin page to check WP_DEBUG, log file access, and WP All Import hooks
- Log a test message when diagnostics pass
- Bump plugin version to 1.9.16 and document change

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_68b602ad917483278f7ef9672ddd0042