### PR TITLE
Fix import log with WP All Import 4.8+

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.16
+ * Version: 1.9.17
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.16
+Stable tag: 1.9.17
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.17 =
+* Fix import logger not running on WP All Import 4.8+ by capturing the import ID.
+
 = 1.9.16 =
 * Add diagnostics on Import Log page to help troubleshoot missing log entries.
 


### PR DESCRIPTION
## Summary
- Capture WP All Import ID from `pmxi_before_post_import` to restore import logging in new WPAI versions
- Reset cached import ID after each import
- Bump plugin version to 1.9.17

## Testing
- `php -l gn-additional-stock-location.php`
- `php -l includes/class-gn-asl-import-sync.php`


------
https://chatgpt.com/codex/tasks/task_e_68b605208bc48327b5f7e6332498138e