### PR TITLE
Fix secondary stock summing for variations

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.18
+ * Version: 1.9.19
  * Author: George Nicolaou
  */
 

--- a/includes/class-gn-asl-import-sync.php
+++ b/includes/class-gn-asl-import-sync.php
@@ -194,7 +194,8 @@ final class Module {
             } elseif (isset($xml->sizes)) {
                 foreach ($xml->sizes->children() as $item) {
                     if (isset($item->available_quantity)) {
-                        $secondary += (int) $item->available_quantity;
+                        $secondary = (int) $item->available_quantity;
+                        break;
                     }
                 }
             }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.18
+Stable tag: 1.9.19
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.19 =
+* Use per-variation quantity for secondary stock instead of summing all sizes.
+
 = 1.9.18 =
 * Bump version to 1.9.18.
 


### PR DESCRIPTION
## Summary
- avoid summing all sizes when extracting secondary stock from XML
- bump plugin version to 1.9.19

## Testing
- `php -l includes/class-gn-asl-import-sync.php`
- `php -l gn-additional-stock-location.php`


------
https://chatgpt.com/codex/tasks/task_e_68b60b7704808327b77d9a9df328d5d3