### PR TITLE
Normalize variation SKU format and bump version

### DIFF
--- a/gn-additional-stock-location.php
+++ b/gn-additional-stock-location.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Additional Stock Location
  * Description: Adds a second stock location field to WooCommerce products and manages stock during checkout.
- * Version: 1.9.19
+ * Version: 1.9.20
  * Author: George Nicolaou
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: yourname
 Tags: woocommerce, inventory, stock
 Requires at least: 5.0
 Tested up to: 6.5
-Stable tag: 1.9.19
+Stable tag: 1.9.20
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -21,6 +21,9 @@ When the primary location is empty you can also specify a **Golden Sneakers Sale
 3. Edit a product to enter values for **Golden Sneakers Stock** and **Golden Sneakers Price**. Variations have their own fields as well.
 
 == Changelog ==
+= 1.9.20 =
+* Ensure variation SKUs use the parent SKU and size (e.g. `HV0823-36.5`).
+
 = 1.9.19 =
 * Use per-variation quantity for secondary stock instead of summing all sizes.
 


### PR DESCRIPTION
## Summary
- Ensure variation SKUs are generated from the parent SKU and size attribute
- Bump plugin version to 1.9.20
- Document change in readme

## Testing
- `php -l includes/class-gn-asl-import-sync.php`
- `php -l gn-additional-stock-location.php`


------
https://chatgpt.com/codex/tasks/task_e_68b61005bdf48327b84daa340be8face